### PR TITLE
Setup own Aeternity node in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,39 @@ env:
     - LIBSODIUM_VER=1.0.16
 
 before_install: 
+  - bash <(curl -s https://raw.githubusercontent.com/aeternity/installer/v2.0.0/install.sh)
+  - mkdir -p $HOME/.epoch/epoch/
+  - touch $HOME/.epoch/epoch/epoch.yaml
+  - echo "
+    ---
+     peers:
+         - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3011" # wrong port
+     fork_management:
+         network_id: "my_test" 
+     chain:
+         persist: true
+     http:
+         external:
+           port: 3013
+         internal:
+           port: 3113
+           listen_address: 0.0.0.0
+           debug_endpoints: true
+     mining:
+         autostart: true
+         expected_mine_rate: 100
+         # Public key of beneficiary account that will receive fees from mining on a node.
+         beneficiary: "ak_JV5aveau3CmasD5UfA1WanyJD9BRAow8315sdgcSRYTKUnrkk"
+         cuckoo:
+             miner:
+                 # Use the fast executable binary of the miner.
+                 executable: mean15-generic
+                 # Extra arguments to pass to the miner executable binary.
+                 extra_args: "-t 1"
+                 # Use the smaller graph for faster mining
+                 edge_bits: 15
+    "  >> $HOME/.epoch/epoch/epoch.yaml
+  - $HOME/aeternity/node/bin/aeternity start
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
   - echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - asdf global java oracle-8.141
   - mix local.rebar --force
   - mix local.hex --force 
-  - mix build_api v1.0.0-elixir v2.2.0 
+  - mix build_api v1.0.0-elixir v${AETERNITY_VERSION} 
   - mix deps.get
   - mix clean
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ elixir: '1.8'
 
 env:
   global:
+    - AETERNITY_VERSION=2.5.0
     - LD_LIBRARY_PATH=$HOME/.libsodium/lib:$LD_LIBRARY_PATH
     - LD_RUN_PATH=$HOME/.libsodium/lib:$LD_RUN_PATH
     - PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include:$HOME/.kiex
@@ -17,8 +18,8 @@ env:
 
 before_install: 
   - sudo apt install wget
-  - wget https://github.com/aeternity/aeternity/releases/download/v2.5.0/aeternity-2.5.0-ubuntu-x86_64.tar.gz
-  - tar -xvf aeternity-2.5.0-ubuntu-x86_64.tar.gz
+  - wget https://github.com/aeternity/aeternity/releases/download/v${AETERNITY_VERSION}/aeternity-${AETERNITY_VERSION}-ubuntu-x86_64.tar.gz
+  - tar -xvf aeternity-${AETERNITY_VERSION}-ubuntu-x86_64.tar.gz
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
   - echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-sudo: false
+sudo: true
 
 language: elixir
 elixir: '1.8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,42 +11,12 @@ env:
     - PATH=$PATH:$HOME/.libsodium/lib:$HOME/.libsodium/include:$HOME/.kiex
     - LIBRARY_PATH=$HOME/.libsodium/lib:$LIBRARY_PATH
     - C_INCLUDE_PATH=$HOME/.libsodium/include:$C_INCLUDE_PATH
+    - AETERNITY_TOP=./
   matrix:
     - LIBSODIUM_VER=1.0.16
 
 before_install: 
   - bash <(curl -s https://raw.githubusercontent.com/aeternity/installer/v2.0.0/install.sh)
-  - mkdir -p $HOME/.epoch/epoch/
-  - touch $HOME/.epoch/epoch/epoch.yaml
-  - echo "
-    ---
-     peers:
-         - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3011" # wrong port
-     fork_management:
-         network_id: "my_test" 
-     chain:
-         persist: true
-     http:
-         external:
-           port: 3013
-         internal:
-           port: 3113
-           listen_address: 0.0.0.0
-           debug_endpoints: true
-     mining:
-         autostart: true
-         expected_mine_rate: 100
-         # Public key of beneficiary account that will receive fees from mining on a node.
-         beneficiary: "ak_JV5aveau3CmasD5UfA1WanyJD9BRAow8315sdgcSRYTKUnrkk"
-         cuckoo:
-             miner:
-                 # Use the fast executable binary of the miner.
-                 executable: mean15-generic
-                 # Extra arguments to pass to the miner executable binary.
-                 extra_args: "-t 1"
-                 # Use the smaller graph for faster mining
-                 edge_bits: 15
-    "  >> $HOME/.epoch/epoch/epoch.yaml
   - $HOME/aeternity/node/bin/aeternity start
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - sudo apt install wget
   - wget https://github.com/aeternity/aeternity/releases/download/v2.5.0/aeternity-2.5.0-ubuntu-x86_64.tar.gz
   - tar -xvf aeternity-2.5.0-ubuntu-x86_64.tar.gz
-  - ./aeternity start
+  - ./bin/aeternity start
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
   - echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
   - sudo apt install wget
   - wget https://github.com/aeternity/aeternity/releases/download/v2.5.0/aeternity-2.5.0-ubuntu-x86_64.tar.gz
   - tar -xvf aeternity-2.5.0-ubuntu-x86_64.tar.gz
-  - ./bin/aeternity start
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
   - echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
@@ -50,6 +49,7 @@ install:
   - "[ -z $LIBSODIUM_NEW ] || (mix deps.compile enacl)"
 
 script:
+  - ./bin/aeternity start
   - mix format --check-formatted
   - mix compile --warnings-as-errors
   - mix compile.xref --warnings-as-errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-sudo: true
+sudo: false
 
 language: elixir
 elixir: '1.8'
@@ -16,8 +16,10 @@ env:
     - LIBSODIUM_VER=1.0.16
 
 before_install: 
-  - bash <(curl -s https://raw.githubusercontent.com/aeternity/installer/v2.0.0/install.sh)
-  - $HOME/aeternity/node/bin/aeternity start
+  - sudo apt install wget
+  - wget https://github.com/aeternity/aeternity/releases/download/v2.5.0/aeternity-2.5.0-ubuntu-x86_64.tar.gz
+  - tar -xvf aeternity-2.5.0-ubuntu-x86_64.tar.gz
+  - ./aeternity start
   - git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.1
   - echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
   - echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
@@ -43,6 +45,7 @@ install:
   - "[ -d $HOME/.libsodium/lib ] || (./configure --prefix=$HOME/.libsodium && make -j$(nproc) && make install && export LIBSODIUM_NEW=yes)"
   - cd ..
 
+  - sudo apt-get install libssl1.0.0
   # Recompile enacl if necessary
   - "[ -z $LIBSODIUM_NEW ] || (mix deps.compile enacl)"
 

--- a/aeternity.yaml
+++ b/aeternity.yaml
@@ -1,0 +1,27 @@
+---
+peers:
+    - "aenode://pp_2i8N6XsjCGe1wkdMhDRs7t7xzijrjJDN4xA22RoNGCgt6ay9QB@31.13.249.70:3011" # wrong port
+fork_management:
+    network_id: "my_test" 
+chain:
+    persist: true
+http:
+    external:
+      port: 3013
+    internal:
+      port: 3113
+      listen_address: 0.0.0.0
+      debug_endpoints: true
+mining:
+    autostart: true
+    expected_mine_rate: 100
+    # Public key of beneficiary account that will receive fees from mining on a node.
+    beneficiary: "ak_JV5aveau3CmasD5UfA1WanyJD9BRAow8315sdgcSRYTKUnrkk"
+    cuckoo:
+        miner:
+            # Use the fast executable binary of the miner.
+            executable: mean15-generic
+            # Extra arguments to pass to the miner executable binary.
+            extra_args: "-t 1"
+            # Use the smaller graph for faster mining
+            edge_bits: 15

--- a/aeternity.yaml
+++ b/aeternity.yaml
@@ -4,7 +4,7 @@ peers:
 fork_management:
     network_id: "my_test" 
 chain:
-    persist: true
+    persist: false
 http:
     external:
       port: 3013

--- a/aeternity.yaml
+++ b/aeternity.yaml
@@ -14,7 +14,8 @@ http:
       debug_endpoints: true
 mining:
     autostart: true
-    expected_mine_rate: 100
+    expected_mine_rate: 1000
+    beneficiary_reward_delay: 2
     # Public key of beneficiary account that will receive fees from mining on a node.
     beneficiary: "ak_6A2vcm1Sz6aqJezkLCssUXcyZTX7X8D5UwbuS2fRJr9KkYpRU"
     cuckoo:

--- a/aeternity.yaml
+++ b/aeternity.yaml
@@ -16,7 +16,7 @@ mining:
     autostart: true
     expected_mine_rate: 100
     # Public key of beneficiary account that will receive fees from mining on a node.
-    beneficiary: "ak_JV5aveau3CmasD5UfA1WanyJD9BRAow8315sdgcSRYTKUnrkk"
+    beneficiary: "ak_6A2vcm1Sz6aqJezkLCssUXcyZTX7X8D5UwbuS2fRJr9KkYpRU"
     cuckoo:
         miner:
             # Use the fast executable binary of the miner.

--- a/apps/utils/test/test_utils.ex
+++ b/apps/utils/test/test_utils.ex
@@ -294,8 +294,8 @@ defmodule TestUtils do
             "a7a695f999b1872acb13d5b63a830a8ee060ba688a478a08c6e65dfad8a01cd70bb4ed7927f97b51e1bcb5e1340d12335b2a2b12c8bc5221d63c4bcb39d41e61"
         },
         "my_test",
-        "https://localhost:3013/v2",
-        "https://localhost:3113/v2"
+        "http://localhost:3013/v2",
+        "http://localhost:3113/v2"
       )
 
     valid_pub_key = "ak_6A2vcm1Sz6aqJezkLCssUXcyZTX7X8D5UwbuS2fRJr9KkYpRU"

--- a/apps/utils/test/test_utils.ex
+++ b/apps/utils/test/test_utils.ex
@@ -293,9 +293,9 @@ defmodule TestUtils do
           secret:
             "a7a695f999b1872acb13d5b63a830a8ee060ba688a478a08c6e65dfad8a01cd70bb4ed7927f97b51e1bcb5e1340d12335b2a2b12c8bc5221d63c4bcb39d41e61"
         },
-        "ae_uat",
-        "https://sdk-testnet.aepps.com/v2",
-        "https://sdk-testnet.aepps.com/v2"
+        "my_test",
+        "https://localhost:3013/v2",
+        "https://localhost:3113/v2"
       )
 
     valid_pub_key = "ak_6A2vcm1Sz6aqJezkLCssUXcyZTX7X8D5UwbuS2fRJr9KkYpRU"

--- a/apps/utils/test/transaction_util_test.exs
+++ b/apps/utils/test/transaction_util_test.exs
@@ -44,6 +44,7 @@ defmodule TransactionUtilTest do
              Transaction.calculate_min_fee(fields.contract_call_tx, 50_000, "ae_mainnet")
   end
 
+  @tag :travis_test
   test "post valid spend transaction", fields do
     assert {:ok, %{}} =
              Account.spend(


### PR DESCRIPTION
resolves #41 
To run the tests locally use the command ` mix test --exclude travis_test`, because these tests need working `aeternity node`.