### PR TITLE
Document core function options

### DIFF
--- a/apps/core/lib/account.ex
+++ b/apps/core/lib/account.ex
@@ -20,7 +20,7 @@ defmodule Core.Account do
   @type spend_options :: [
           fee: non_neg_integer(),
           ttl: non_neg_integer(),
-          payload: non_neg_integer()
+          payload: String.t()
         ]
 
   @doc """

--- a/apps/core/lib/account.ex
+++ b/apps/core/lib/account.ex
@@ -17,6 +17,11 @@ defmodule Core.Account do
   @allowed_recipient_tags ["ak", "ct", "ok", "nm"]
 
   @type account :: %{id: String.t(), balance: non_neg_integer(), nonce: non_neg_integer()}
+  @type spend_options :: [
+          fee: non_neg_integer(),
+          ttl: non_neg_integer(),
+          payload: non_neg_integer()
+        ]
 
   @doc """
   Send tokens to an account.
@@ -32,7 +37,7 @@ defmodule Core.Account do
           tx_hash: "th_FBqci65KYGsup7GettzvWVxP91podgngX9EJK2BDiduFf8FY4"
         }}
   """
-  @spec spend(Client.t(), binary(), non_neg_integer(), list()) ::
+  @spec spend(Client.t(), binary(), non_neg_integer(), spend_options()) ::
           {:ok,
            %{
              block_hash: Encoding.base58c(),

--- a/apps/core/lib/chain.ex
+++ b/apps/core/lib/chain.ex
@@ -37,6 +37,7 @@ defmodule Core.Chain do
   alias Core.Client
   alias Tesla.Env
 
+  @type await_options :: [attempts: non_neg_integer(), interval: non_neg_integer()]
   @type generic_transaction :: %{version: non_neg_integer(), type: String.t()}
   @type generic_signed_transaction :: %{
           tx: generic_transaction(),
@@ -146,7 +147,7 @@ defmodule Core.Chain do
       iex> Core.Chain.await_height(client, 84590)
       :ok
   """
-  @spec await_height(Client.t(), non_neg_integer(), list()) ::
+  @spec await_height(Client.t(), non_neg_integer(), await_options()) ::
           :ok | {:error, String.t()} | {:error, Env.t()}
   def await_height(%Client{} = client, height, opts \\ [])
       when is_integer(height) and height > 0 do
@@ -166,7 +167,7 @@ defmodule Core.Chain do
       iex> Core.Chain.await_transaction(client, transaction_hash)
       :ok
   """
-  @spec await_transaction(Client.t(), String.t(), list()) ::
+  @spec await_transaction(Client.t(), String.t(), await_options()) ::
           :ok | {:error, String.t()} | {:error, Env.t()}
   def await_transaction(%Client{connection: connection}, tx_hash, opts \\ [])
       when is_binary(tx_hash) do

--- a/apps/core/lib/contract.ex
+++ b/apps/core/lib/contract.ex
@@ -32,6 +32,23 @@ defmodule Core.Contract do
   @init_function "init"
   @abi_version 0x01
 
+  @type deploy_options :: [
+          deposit: non_neg_integer(),
+          amount: non_neg_integer(),
+          gas: non_neg_integer(),
+          gas_price: non_neg_integer(),
+          fee: non_neg_integer(),
+          ttl: non_neg_integer()
+        ]
+
+  @type call_options :: [
+          fee: non_neg_integer(),
+          ttl: non_neg_integer(),
+          amount: non_neg_integer(),
+          gas: non_neg_integer(),
+          gas_price: non_neg_integer()
+        ]
+
   @doc """
   Deploy a contract
 
@@ -54,7 +71,7 @@ defmodule Core.Contract do
           Client.t(),
           String.t(),
           list(String.t()),
-          list()
+          deploy_options()
         ) ::
           {:ok,
            %{
@@ -166,7 +183,7 @@ defmodule Core.Contract do
        }}
 
   """
-  @spec call(Client.t(), String.t(), String.t(), String.t(), list(String.t()), list()) ::
+  @spec call(Client.t(), String.t(), String.t(), String.t(), list(String.t()), call_options()) ::
           {:ok,
            %{
              block_hash: Encoding.base58c(),
@@ -244,7 +261,14 @@ defmodule Core.Contract do
           log: []
         }}
   """
-  @spec call_static(Client.t(), String.t(), String.t(), String.t(), list(String.t()), list()) ::
+  @spec call_static(
+          Client.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          list(String.t()),
+          call_options()
+        ) ::
           {:ok,
            %{
              return_value: String.t(),

--- a/apps/core/lib/name.ex
+++ b/apps/core/lib/name.ex
@@ -27,6 +27,8 @@ defmodule Core.AENS do
   @max_name_ttl 50_000
   @max_client_ttl 86_000
 
+  @type aens_options :: [fee: non_neg_integer(), ttl: non_neg_integer()]
+
   @doc """
   Preclaims a name.
 
@@ -62,7 +64,7 @@ defmodule Core.AENS do
           tx_hash: "th_wYo5DLruahJrkFwjH5Jji6HsRMbPZBxeJKmRwg8QEyKVYrXGd"
         }}
   """
-  @spec preclaim(Client.t(), String.t(), non_neg_integer() | atom(), list()) ::
+  @spec preclaim(Client.t(), String.t(), non_neg_integer() | atom(), aens_options()) ::
           {:error, String.t()} | {:ok, map()}
   def preclaim(
         %Client{
@@ -156,7 +158,8 @@ defmodule Core.AENS do
        }}
 
   """
-  @spec claim({:ok, map()} | {:error, String.t()}, list) :: {:error, String.t()} | {:ok, map()}
+  @spec claim({:ok, map()} | {:error, String.t()}, aens_options()) ::
+          {:error, String.t()} | {:ok, map()}
   def claim(preclaim_result, opts \\ []) do
     case preclaim_result do
       {:ok, %{client: client, name: name, name_salt: name_salt}} ->
@@ -203,7 +206,8 @@ defmodule Core.AENS do
          }}
   """
 
-  @spec claim(Client.t(), String.t(), integer(), list()) :: {:error, String.t()} | {:ok, map()}
+  @spec claim(Client.t(), String.t(), integer(), aens_options()) ::
+          {:error, String.t()} | {:ok, map()}
   def claim(
         %Client{
           keypair: %{
@@ -295,7 +299,7 @@ defmodule Core.AENS do
           list(),
           non_neg_integer(),
           non_neg_integer(),
-          list()
+          aens_options()
         ) :: {:error, String.t()} | {:ok, map()}
   def update(
         claim_result,
@@ -360,7 +364,7 @@ defmodule Core.AENS do
           non_neg_integer(),
           list(),
           non_neg_integer(),
-          list()
+          aens_options()
         ) :: {:error, String.t()} | {:ok, map()}
   def update_name(
         %Client{
@@ -455,7 +459,7 @@ defmodule Core.AENS do
   @spec transfer(
           {:ok, %{client: Core.Client.t(), name: binary()} | {:error, String.t()}},
           binary(),
-          list()
+          aens_options()
         ) ::
           {:error, String.t()} | {:ok, map()}
   def transfer(claim_result, recipient_pub_key, opts \\ []) do
@@ -504,7 +508,7 @@ defmodule Core.AENS do
            tx_hash: "th_2Bxxz5j4rexSCRC227oR4E6zBD14MCFh2qhZoNMDiCjzpVv8Qi"
          }}
   """
-  @spec transfer_name(Client.t(), String.t(), binary(), list()) ::
+  @spec transfer_name(Client.t(), String.t(), binary(), aens_options()) ::
           {:error, String.t()} | {:ok, map()}
   def transfer_name(
         %Client{
@@ -587,7 +591,8 @@ defmodule Core.AENS do
          }}
   """
 
-  @spec revoke({:ok, map()}, list() | {:error, String.t()}) :: {:error, String.t()} | {:ok, map()}
+  @spec revoke({:ok, map()} | {:error, String.t()}, aens_options()) ::
+          {:error, String.t()} | {:ok, map()}
   def revoke(claim_result, opts \\ []) do
     case claim_result do
       {:ok, %{client: client, name: name}} ->
@@ -633,7 +638,7 @@ defmodule Core.AENS do
         }}
   """
 
-  @spec revoke_name(Client.t(), String.t(), list()) :: {:error, String.t()} | {:ok, map()}
+  @spec revoke_name(Client.t(), String.t(), aens_options()) :: {:error, String.t()} | {:ok, map()}
   def revoke_name(
         %Client{
           keypair: %{

--- a/apps/core/lib/oracle.ex
+++ b/apps/core/lib/oracle.ex
@@ -33,6 +33,12 @@ defmodule Core.Oracle do
   @type sophia_data :: any()
   @type ttl_type :: :relative | :absolute
   @type ttl :: %{type: ttl_type(), value: non_neg_integer()}
+  @type oracle_options() :: [fee: non_neg_integer(), ttl: non_neg_integer()]
+  @type query_options() :: [
+          fee: non_neg_integer(),
+          ttl: non_neg_integer(),
+          query_fee: non_neg_integer()
+        ]
 
   @doc """
   Register a typed oracle. Queries and responses that don't follow the oracle's respective formats are invalid.
@@ -58,7 +64,7 @@ defmodule Core.Oracle do
           sophia_type(),
           ttl(),
           non_neg_integer(),
-          list()
+          oracle_options()
         ) ::
           {:ok,
            %{
@@ -134,7 +140,14 @@ defmodule Core.Oracle do
          tx_hash: "th_2esUdavCBmW1oYSCichdQv3txyWXYsDSAum2jAvQfpgktJ4oEt"
        }}
   """
-  @spec query(Client.t(), Encoding.base58c(), String.t(), ttl(), non_neg_integer(), list()) ::
+  @spec query(
+          Client.t(),
+          Encoding.base58c(),
+          String.t(),
+          ttl(),
+          non_neg_integer(),
+          query_options()
+        ) ::
           {:ok,
            %{
              block_hash: Encoding.base58c(),
@@ -221,7 +234,7 @@ defmodule Core.Oracle do
           Encoding.base58c(),
           sophia_data(),
           non_neg_integer(),
-          list()
+          oracle_options()
         ) ::
           {:ok,
            %{
@@ -287,7 +300,7 @@ defmodule Core.Oracle do
          tx_hash: "th_3911tboNbJWA6X57tejX8yGQALdeqAQECk1BwyS43pPtEXt4C"
        }}
   """
-  @spec extend(Client.t(), Encoding.base58c(), non_neg_integer(), list()) ::
+  @spec extend(Client.t(), Encoding.base58c(), non_neg_integer(), oracle_options()) ::
           {:ok,
            %{
              block_hash: Encoding.base58c(),

--- a/apps/utils/lib/transaction.ex
+++ b/apps/utils/lib/transaction.ex
@@ -43,6 +43,15 @@ defmodule Utils.Transaction do
     ContractCreateTx
   ]
 
+  @network_id_list ["ae_mainnet", "ae_uat"]
+
+  @await_attempts 25
+  @await_attempt_interval 200
+  @default_ttl 0
+  @dummy_fee 0
+  @tx_posting_attempts 5
+  @default_payload ""
+
   @type tx_types ::
           SpendTx.t()
           | OracleRegisterTx.t()
@@ -56,15 +65,6 @@ defmodule Utils.Transaction do
           | NameUpdateTx.t()
           | ContractCallTx.t()
           | ContractCreateTx.t()
-
-  @network_id_list ["ae_mainnet", "ae_uat"]
-
-  @await_attempts 25
-  @await_attempt_interval 200
-  @default_ttl 0
-  @dummy_fee 0
-  @tx_posting_attempts 5
-  @default_payload ""
 
   @spec default_ttl :: non_neg_integer()
   def default_ttl, do: @default_ttl


### PR DESCRIPTION
Decided to keep it simpler, by just adding types for the options. Parameter names and types are self-explanatory well enough, and easy to be accessed within the docs as well

resolves #69 