### PR TITLE
Automatically determine if a transaction is on-chain or dry-run in Contract.call

### DIFF
--- a/test/core_contract_test.exs
+++ b/test/core_contract_test.exs
@@ -24,7 +24,10 @@ defmodule CoreContractTest do
       entrypoint init(x : int) =
         { number = x }
 
-      entrypoint add_to_number(x : int) =
+      entrypoint get_number() =
+        state.number
+
+      stateful entrypoint add_to_number(x : int) =
         Chain.event(AddedNumberEvent(x, \"Added a number\"))
         state.number + x"
     [client: client, source_code: source_code]
@@ -43,7 +46,7 @@ defmodule CoreContractTest do
 
     {:ok, %{contract_id: ct_address}} = deploy_result
 
-    call_result =
+    on_chain_call_result =
       Contract.call(
         setup_data.client,
         ct_address,
@@ -52,23 +55,23 @@ defmodule CoreContractTest do
         ["33"]
       )
 
-    assert match?({:ok, %{return_value: _, return_type: "ok"}}, call_result)
+    assert match?({:ok, %{return_value: _, return_type: "ok"}}, on_chain_call_result)
 
-    refute call_result |> elem(1) |> Map.get(:log) |> Enum.empty?()
+    refute on_chain_call_result |> elem(1) |> Map.get(:log) |> Enum.empty?()
 
-    call_static_result =
-      Contract.call_static(
+    static_call_result =
+      Contract.call(
         setup_data.client,
         ct_address,
         setup_data.source_code,
-        "add_to_number",
-        ["33"],
+        "get_number",
+        [],
         fee: 10_000_000_000_000_000
       )
 
-    assert match?({:ok, %{return_value: _, return_type: "ok"}}, call_static_result)
+    assert match?({:ok, %{return_value: _, return_type: "ok"}}, static_call_result)
 
-    {:ok, %{return_value: data, return_type: "ok"}} = call_result
+    {:ok, %{return_value: data, return_type: "ok"}} = on_chain_call_result
 
     assert {:ok, data} ==
              Contract.decode_return_value(
@@ -80,31 +83,31 @@ defmodule CoreContractTest do
     %{public: low_balance_public_key} = low_balance_keypair = Keys.generate_keypair()
     Account.spend(setup_data.client, low_balance_public_key, 1)
 
-    call_static_result =
-      Contract.call_static(
+    static_call_result =
+      Contract.call(
         %Client{setup_data.client | keypair: low_balance_keypair},
         ct_address,
         setup_data.source_code,
-        "add_to_number",
-        ["33"],
+        "get_number",
+        [],
         fee: 10_000_000_000_000_000
       )
 
-    assert match?({:ok, %{return_value: _, return_type: "ok"}}, call_static_result)
+    assert match?({:ok, %{return_value: _, return_type: "ok"}}, static_call_result)
 
     non_existing_keypair = Keys.generate_keypair()
 
-    call_static_result =
-      Contract.call_static(
+    static_call_result =
+      Contract.call(
         %Client{setup_data.client | keypair: non_existing_keypair},
         ct_address,
         setup_data.source_code,
-        "add_to_number",
-        ["33"],
+        "get_number",
+        [],
         fee: 10_000_000_000_000_000
       )
 
-    assert match?({:ok, %{return_value: _, return_type: "ok"}}, call_static_result)
+    assert match?({:ok, %{return_value: _, return_type: "ok"}}, static_call_result)
   end
 
   @tag :travis_test
@@ -129,7 +132,7 @@ defmodule CoreContractTest do
 
     {:ok, %{contract_id: ct_address}} = deploy_result
 
-    call_result =
+    on_chain_call_result =
       Contract.call(
         setup_data.client,
         ct_address,
@@ -138,7 +141,7 @@ defmodule CoreContractTest do
         ["33"]
       )
 
-    assert match?({:error, _}, call_result)
+    assert match?({:error, "Undefined function non_existing_function"}, on_chain_call_result)
   end
 
   @tag :travis_test
@@ -154,8 +157,8 @@ defmodule CoreContractTest do
 
     {:ok, %{contract_id: ct_address}} = deploy_result
 
-    call_result =
-      Contract.call_static(
+    static_call_result =
+      Contract.call(
         setup_data.client,
         ct_address,
         setup_data.source_code,
@@ -164,7 +167,7 @@ defmodule CoreContractTest do
         fee: 10_000_000_000_000_000
       )
 
-    assert match?({:error, _}, call_result)
+    assert match?({:error, "Undefined function non_existing_function"}, static_call_result)
   end
 
   @tag :travis_test
@@ -180,7 +183,7 @@ defmodule CoreContractTest do
 
     {:ok, %{contract_id: ct_address}} = deploy_result
 
-    call_result =
+    on_chain_call_result =
       Contract.call(
         setup_data.client,
         ct_address,
@@ -189,9 +192,9 @@ defmodule CoreContractTest do
         ["33"]
       )
 
-    assert match?({:ok, %{return_value: _, return_type: "ok"}}, call_result)
+    assert match?({:ok, %{return_value: _, return_type: "ok"}}, on_chain_call_result)
 
-    {:ok, %{return_value: _, return_type: "ok"}} = call_result
+    {:ok, %{return_value: _, return_type: "ok"}} = on_chain_call_result
 
     assert {:error,
             {:badmatch,

--- a/test/core_listener_test.exs
+++ b/test/core_listener_test.exs
@@ -24,7 +24,7 @@ defmodule CoreListenerTest do
         entrypoint init(x : int) =
           { number = x }
 
-        entrypoint add_to_number(x : int) =
+        stateful entrypoint add_to_number(x : int) =
           Chain.event(AddedNumberEvent(x, \"Added a number\"))
           state.number + x"
     [client: client, source_code: source_code]


### PR DESCRIPTION
resolves #126 
To be merged after [Allow dry-run without a keypair](https://github.com/aeternity/aepp-sdk-elixir/pull/124)